### PR TITLE
Change the final comment period to 3 calendar days

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ comments.
 * Eventually, the team will decide whether the RFC is a candidate
 for inclusion in React.
 * RFCs that are candidates for inclusion in React will enter a "final comment
-period" lasting 7 days. The beginning of this period will be signaled with a
+period" lasting 3 calendar days. The beginning of this period will be signaled with a
 comment and tag on the RFCs pull request.
 * An RFC can be modified based upon feedback from the team and community.
 Significant modifications may trigger a new final comment period.


### PR DESCRIPTION
Per discussion with @bvaughn @acdlite this lets us move a bit faster.

With previous RFCs we completely missed this part of the process. I think it's more realistic if we tune this to the actual speed that we need to iterate quickly.