### PR TITLE
ES Module as allowed component type

### DIFF
--- a/text/0000-module-component-type.md
+++ b/text/0000-module-component-type.md
@@ -1,0 +1,133 @@
+- Start Date: 2020-02-15
+- RFC PR: (leave this empty)
+- React Issue: (leave this empty)
+
+# Summary
+
+If `MyComponent` is an esModule, then resolve `<MyComponent>` as `React.createElement(MyComponent.default)`.
+
+# Basic example
+
+In the following code:
+
+```jsx
+import * as Tabs from './tabs';
+
+export default = () => <Tabs>
+    <Tabs.Tab />
+</Tabs>
+```
+
+Resolve `<Tabs>` as `React.createElement(Tabs.default)`
+
+# Motivation
+
+A common way of exporting interlinked React Components is to use a Compound Component pattern:
+
+```jsx
+const Tabs = ({children}) => <div>
+    { children }
+</div>;
+
+const Tab = ({children}) => <div>
+    { children }
+</div>;
+
+Tabs.Tab = Tab;
+
+export default Tab;
+```
+
+This results in a syntax that clearly shows the relationship between the two components:
+
+```jsx
+import Tabs from './tabs';
+
+export default = () => <Tabs>
+    <Tabs.Tab />
+    <Tabs.Tab />
+</Tabs>;
+```
+
+Unfortunately, if a compound component contains several optional child components, this technique does not benefit from tree shaking.
+
+This can be resolved as follows:
+
+```jsx
+
+const Tabs = ({children}) => <div>
+    { children }
+</div>
+
+const Tab = ({children}) => <div>
+    { children }
+</div>;
+
+export { Tabs, Tab };
+export default Tab;
+```
+
+But the code utilising this code must look as follows:
+
+```jsx
+import * as Tabs from './tabs';
+
+export default = () => <Tabs.Tabs>
+    <Tabs.Tab />
+    <Tabs.Tab />
+</Tabs.Tabs>;
+```
+
+The addition of `.Tabs` complicates the code, especially when dealing with larger component names.
+
+On the other hand, `<Tabs>` should suffice, but this would require a change to JSX transpilation or React runtime.
+
+# Detailed design
+
+I see 2 possible routes, though am still assessing them:
+
+## Change to babel-plugin-react-jsx
+
+If we can statically analyse `MyComponent` and identify it is an es module, then it may be possible to do this during transpilation.
+
+## Handle at runtime
+
+e.g. in `packages/react-reconciler/src/ReactFiber.js`, after case statements but before error:
+
+```js
+          if (type.default != null) {
+            return (createFiberFromTypeAndProps(type.default,
+              key, pendingProps, owner, mode, expirationTime))
+          }
+```
+
+# Drawbacks
+
+- Handling at runtime may cause issues in transpiled code, when trying to detect whether a component passed in was originally an esModule.
+- I don't know enough about the babel plugin to identify issues
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Adoption strategy
+
+If we implement this proposal, how will existing React developers adopt it? Is
+this a breaking change? Can we write a codemod? Should we coordinate with
+other projects or libraries?
+
+# How we teach this
+
+What names and terminology work best for these concepts and why? How is this
+idea best presented? As a continuation of existing React patterns?
+
+Would the acceptance of this proposal mean the React documentation must be
+re-organized or altered? Does it change how React is taught to new developers
+at any level?
+
+How should this feature be taught to existing React developers?
+
+# Unresolved questions
+
+Optional, but suggested for first drafts. What parts of the design are still
+TBD?

--- a/text/0000-module-component-type.md
+++ b/text/0000-module-component-type.md
@@ -13,42 +13,42 @@ If `MyComponent` is an ES Module, then `<MyComponent>` should behave the same as
 In the following code:
 
 ```jsx
-import * as Tabs from './tabs';
+import * as ControlPanel from './control-panel';
 
-export default = () => <Tabs>
-    <Tabs.Tab />
-</Tabs>
+export default = () => <ControlPanel>
+    <ControlPanel.Button />
+</ControlPanel>
 ```
 
-Resolve `<Tabs>` as `<Tabs.default>`.
+Resolve `<ControlPanel>` as `<ControlPanel.default>`.
 
 # Motivation
 
 A [common](https://kentcdodds.com/blog/compound-components-with-react-hooks) way of exporting interlinked React Components is to use a [Compound Component pattern](https://egghead.io/lessons/react-write-compound-components):
 
 ```jsx
-const Tabs = ({children}) => <div>
+const ControlPanel = ({children}) => <div>
     { children }
 </div>;
 
-const Tab = ({children}) => <div>
+const Button = ({children}) => <div>
     { children }
 </div>;
 
-Tabs.Tab = Tab;
+ControlPanel.Button = Button;
 
-export default Tab;
+export default ControlPanel;
 ```
 
 This results in a syntax that clearly shows the relationship between the two components:
 
 ```jsx
-import Tabs from './tabs';
+import ControlPanel from './control-panel';
 
-export default = () => <Tabs>
-    <Tabs.Tab />
-    <Tabs.Tab />
-</Tabs>;
+export default = () => <ControlPanel>
+    <ControlPanel.Button />
+    <ControlPanel.Button />
+</ControlPanel>;
 ```
 
 Unfortunately, if a compound component contains several optional child components, this technique does not benefit from tree shaking.
@@ -57,43 +57,59 @@ This can be resolved as follows:
 
 ```jsx
 
-const Tabs = ({children}) => <div>
+const ControlPanel = ({children}) => <div>
     { children }
 </div>
 
-const Tab = ({children}) => <div>
+const Button = ({children}) => <div>
     { children }
 </div>;
 
-export { Tabs, Tab };
-export default Tab;
+export { ControlPanel, Button };
+export default ControlPanel;
 ```
 
 But the code utilising this code must look as follows:
 
 ```jsx
-import * as Tabs from './tabs';
+import ControlPanel, { Button } from './control-panel';
 
-export default = () => <Tabs.Tabs>
-    <Tabs.Tab />
-    <Tabs.Tab />
-</Tabs.Tabs>;
+export default = () => <ControlPanel>
+    <Button />
+    <Button />
+</ControlPanel>;
+
+```
+
+This doesn't use the dot syntax often used for compound components, and so the relationship between these components is not immediately apparent.
+
+So the motivation here is to find a way to use the dot syntax, while still keeping the benefits of tree shaking.
+
+Two options would be:
+
+```jsx
+import * as ControlPanel from './control-panel';
+
+export default = () => <ControlPanel.ControlPanel>
+    <ControlPanel.Button />
+    <ControlPanel.Button />
+</ControlPanel.ControlPanel>;
 ```
 
 or
 
 ```jsx
-import * as Tabs from './tabs';
+import * as ControlPanel from './control-panel';
 
-export default = () => <Tabs.default>
-    <Tabs.Tab />
-    <Tabs.Tab />
-</Tabs.default>;
+export default = () => <ControlPanel.default>
+    <ControlPanel.Button />
+    <ControlPanel.Button />
+</ControlPanel.default>;
 ```
 
-The addition of `.Tabs`/`.default` complicates the code, especially when dealing with larger component names.
+The addition of `.ControlPanel`/`.default` complicates the code, especially when dealing with larger component names.
 
-On the other hand, having `<Tabs>` resolve to `<Tabs.default>` would be a cleaner syntax, but this would require a change to JSX transpilation or React runtime.
+On the other hand, having `<ControlPanel>` resolve to `<ControlPanel.default>` would be a cleaner syntax, but this would require a change to JSX transpilation or React runtime.
 
 # Detailed design
 
@@ -147,7 +163,6 @@ re-organized or altered?*
 *Does it change how React is taught to new developers at any level?*
 
 No
-
 
 # Unresolved questions
 

--- a/text/0000-module-component-type.md
+++ b/text/0000-module-component-type.md
@@ -24,7 +24,7 @@ Resolve `<ControlPanel>` as `<ControlPanel.default>`.
 
 # Motivation
 
-A [common](https://kentcdodds.com/blog/compound-components-with-react-hooks) way of exporting interlinked React Components is to use a [Compound Component pattern](https://egghead.io/lessons/react-write-compound-components):
+A [common](https://kentcdodds.com/blog/compound-components-with-react-hooks) way of exporting interlinked React Components is to use a [Compound Component pattern](https://egghead.io/lessons/react-write-compound-components) with [dot](https://www.jakewiesler.com/blog/compound-component-basics/) [notation](https://medium.com/risan/react-component-with-dot-notation-7a9853dbf33b):
 
 ```jsx
 const ControlPanel = ({children}) => <div>
@@ -81,9 +81,9 @@ export default = () => <ControlPanel>
 
 ```
 
-This doesn't use the dot syntax often used for compound components, and so the relationship between these components is not immediately apparent.
+This doesn't use the dot notation often used for compound components, and so the relationship between these components is not immediately apparent.
 
-So the motivation here is to find a way to use the dot syntax, while still keeping the benefits of tree shaking.
+So the motivation here is to find a way to use the dot notation, while still keeping the benefits of tree shaking.
 
 Two options would be:
 

--- a/text/0000-module-component-type.md
+++ b/text/0000-module-component-type.md
@@ -151,4 +151,5 @@ No
 
 # Unresolved questions
 
-Whether to execute during transpilation or at runtime.
+- Whether to execute during transpilation or at runtime.
+- If this is done at runtime, and the entire Module is passed to `React.createElement`, would tree shaking still be able to remove unused exports?


### PR DESCRIPTION
If `MyComponent` is an ES Module, then `<MyComponent>` should behave the same as `<MyComponent.default>`

(e.g. transpile to `React.createElement(MyComponent.default)`).

This is primarily to support syntax such as the following, while ensuring that tree shaking still will still function (see diff for details):

```jsx
 import ControlPanel from './control-panel';

 export default = () => <ControlPanel>
     <ControlPanel.Button />
     <ControlPanel.Button />
 </ControlPanel>;
 ```