### PR TITLE
[WIP] [DRAFT] RFC: React Module Conventions RFC v3

### DIFF
--- a/text/0000-server-module-conventions.md
+++ b/text/0000-server-module-conventions.md
@@ -1,0 +1,136 @@
+- Start Date: 2023-02-04
+- RFC PR: (leave this empty)
+- React Issue: (leave this empty)
+- Author: Pranav Yadav [@Pranav-yadav](https://github.com/Pranav-yadav) 
+
+# Summary
+
+Better conventions for Server/Client Components, as an revision to [the v2](https://github.com/reactjs/rfcs/pull/227) of [the original proposal v1](https://github.com/reactjs/rfcs/pull/189)
+
+<sup>Note: The v1 and v2 terms used throughout this RFC refer to the above hyperlinked RFCs only.</sup>
+
+# Changes Since v2
+
+- using `"use csr"` instead of `"use client"` i.e. replacing `client` with `csr`
+- similarly, reserve `"use ssr"` for future use with Server only.
+
+# Basic example
+
+<!-- If the proposal involves a new or changed API, include a basic code example.
+Omit this section if it's not applicable. -->
+
+To mark a component as a Client Component, add `'use csr'` directive at the top of your file. This lets you use features like state and event handlers:
+
+```js
+'use csr';
+
+import { useState } from 'react';
+
+function Button({ children, onClick }) {
+  // ...
+}
+```
+
+Diff - current syntax and conventions:
+```diff
++'use csr';
+-'use client';
+
+import { useState } from 'react';
+
+function Button({ children, onClick }) {
+  // ...
+}
+```
+
+## `"use csr"` Directive
+
+```js
+// Parent.js
+import Component from "./Component.js";
+function Parent() {
+  // Component is of type Reference<T> where T is the type
+  // of the default export of Component.js
+  // Because of this React knows that it can't render it on
+  // the server and instead will leave it as a placeholder
+  // to later be rendered on the client.
+  return <Component />;
+}
+```
+
+```js
+// Component.js
+"use csr";
+
+function Component() {
+  let [state, setState] = useState(false);
+  return <OtherClientComponent onClick={() => setState(true)} value={state} />;
+}
+```
+
+# Motivation
+
+<!-- Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+Please focus on explaining the motivation so that if this RFC is not accepted,
+the motivation could be used to develop alternative solutions. In other words,
+enumerate the constraints you are trying to solve without coupling them too
+closely to the solution you have in mind. -->
+
+
+
+# Detailed design
+
+<!-- This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with React to understand, and for somebody familiar with the
+implementation to implement. This should get into specifics and corner-cases,
+and include examples of how the feature is used. Any new terminology should be
+defined here. -->
+
+
+
+# Drawbacks
+
+<!-- 
+Why should we *not* do this? Please consider:
+
+- implementation cost, both in term of code size and complexity
+- whether the proposed feature can be implemented in user space
+- the impact on teaching people React
+- integration of this feature with other existing and planned features
+- cost of migrating existing React applications (is it a breaking change?)
+
+There are tradeoffs to choosing any path. Attempt to identify them here. -->
+
+
+
+# Alternatives
+
+<!-- What other designs have been considered? What is the impact of not doing this? -->
+
+
+
+# Adoption strategy
+<!-- 
+If we implement this proposal, how will existing React developers adopt it? Is
+this a breaking change? Can we write a codemod? Should we coordinate with
+other projects or libraries? -->
+
+# How we teach this
+
+<!-- What names and terminology work best for these concepts and why? How is this
+idea best presented? As a continuation of existing React patterns?
+
+Would the acceptance of this proposal mean the React documentation must be
+re-organized or altered? Does it change how React is taught to new developers
+at any level?
+
+How should this feature be taught to existing React developers? -->
+
+
+# Unresolved questions
+
+<!-- Optional, but suggested for first drafts. What parts of the design are still
+TBD? -->
+


### PR DESCRIPTION
[WIP] [DRAFT]

---

<sup>Originally posted by me; under related RFC v2 PR.</sup>

# Abstract:
In this RFC I propose minor yet effective changes to [the React Module Conventions RFC v2](https://github.com/reactjs/rfcs/pull/227). The term **_"client"_** is too generic both in Software/Web Development as well as in general. This type of _**extra** generalism_ may lead to devastating effects on DX in various aspects. I propose; we should use `"use csr"` instead of `"use client"` to avoid confusion and generalism, by being explicit and not too generic.

# Concerns:

1. `"use client"` : both experienced and newbie React Developer would be confused with the word "client", it's too **_generic_**, and on top of that, it sounds like we're using hooks. <sub>(feeling sorry for classes; no one mentions them these days 😎)</sub>
  I get it, it's not that hard to get used to this but 👇 also, <sub>(see proposal after reading both of these concerns)</sub>
2. This is going to be tough to digest for JS developers, at least for those still working with/seeing `use strict`, in their free time :).
  Since `"use strict"` is supported by the language itself out-of-the-box. Imitating the same syntax will confuse some JS devs and newbies that; `"use client"` is something that's also part of official JS [^1] (which could be devastating).
  <sub>(I get that some of us may be thinking only ɗŭmb devs will have this problem, but, hey, wasn't you also a newbie at some time?)</sub>.
  Don't have hard suggestions on this but _this confusion can be reduced by being_ **_explicit_**.

# Proposal:

1. Using **`"use csr"`** : here we're _being_ **_explicit_**. As almost every frontend/backend dev is familiar w/ what is **CSR** / **`csr`**, it's _not_ that much confusing as compared to **_`client`_**
```diff js
+ 'use csr';
- 'use client';
function doSomething() {
 // ...
}
```

2. Let's _**not**_ use **_too generic_** term and confuse everyone instead let's use specific terms like SSR (ssr) and CSR (csr), that way we're trying to be _explicit_ and the literal meaning is conveyed, leading to improved DX and flexibility.

3. Reserving `"use ssr"` for future use in SSR functionalities i.e. in the context of SSR.
4. Reserving `"use ssg"` for future use in SSG functionalities i.e. in the context of SSG.
5. Reserving `"use isr"` for future use in the context of ISR.

# Glossary

- CSR / `csr`: **C**lient **S**ide **R**endering
- SSR / `ssr`: **S**erver **S**ide **R**endering
- SSG / `ssg`: **S**tatic **S**ite **G**eneration
- ISR / `isr`: **I**ncremental **S**tatic **R**egeneration


# References
[^1]: > **NOTE**
The [ExpressionStatement](https://tc39.es/ecma262/#prod-ExpressionStatement)s of a [Directive Prologue](https://tc39.es/ecma262/#directive-prologue) are evaluated normally during evaluation of the containing production. Implementations may define implementation specific meanings for [ExpressionStatement](https://tc39.es/ecma262/#prod-ExpressionStatement)s which are not a [Use Strict Directive](https://tc39.es/ecma262/#use-strict-directive) and which occur in a [Directive Prologue](https://tc39.es/ecma262/#directive-prologue). If an appropriate notification mechanism exists, an implementation should issue a warning if it encounters in a [Directive Prologue](https://tc39.es/ecma262/#directive-prologue) an [ExpressionStatement](https://tc39.es/ecma262/#prod-ExpressionStatement) that is not a [Use Strict Directive](https://tc39.es/ecma262/#use-strict-directive) and which does not have a meaning defined by the implementation. <p align="right">--- [_TC39/ecma262_](https://tc39.es/ecma262/#use-strict-directive)</p>
